### PR TITLE
Update bti.py

### DIFF
--- a/mne/io/bti/bti.py
+++ b/mne/io/bti/bti.py
@@ -659,10 +659,10 @@ def _read_channel(fid):
                 'ymax': read_double(fid),
                 'index': read_int32(fid),
                 'checksum': read_int32(fid),
-                'off_flag': read_str(fid, 16),
+                'off_flag': read_str(fid, 4),
                 'offset': read_float(fid)})
 
-    fid.seek(12, 1)
+    fid.seek(24, 1)
 
     return out
 


### PR DESCRIPTION
_read_channel() had 'off_flag' string length deviating from
struct dftk_channel_ref_data in 4D/BTi's $STAGE/map/src/include/dftk_channel_ref.h
which can lead to errors in read_raw_bti(), cf. #6048

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://martinos.org/mne/stable/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

#### Reference issue
Fixes #6048.


#### What does this implement/fix?
Adjust  'off_flag' string length to reflect 4D/BTi's char off_flag[4]
in struct dftk_channel_ref_data of $STAGE/map/src/include/dftk_channel_ref.h
(and adjust following seek())


#### Additional information
Any additional information you think is important.
